### PR TITLE
[CSR-1881] feat: added single project for or8n

### DIFF
--- a/.github/workflows/or8n.yml
+++ b/.github/workflows/or8n.yml
@@ -1,0 +1,35 @@
+name: Run or8n Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  e2e_tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        shard: [1, 2, 3]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install Dependencies
+        run: npm install
+
+      - name: Reset NX
+        run: npx nx reset
+
+      - name: Run All E2E Tests
+        env:
+          CURRENTS_API_URL: https://cy-staging.currents.dev
+          CURRENTS_PROJECT_ID: ${{secrets.CURRENTS_PROJECT_ID}}
+          CURRENTS_RECORD_KEY: ${{secrets.CURRENTS_RECORD_KEY}}
+          CURRENTS_CI_BUILD_ID: ${{ github.run_id }}-${{ github.sha }}
+        run: npx nx run-many -t or8n --verbose --base=main~1 --head=HEAD

--- a/README.md
+++ b/README.md
@@ -92,3 +92,25 @@ nx run-many -t e2e  --parallel=2 --verbose --last-failed
 
       - nx run e2e-01:e2e
 ```
+
+## Single project orchestration
+
+The project named `e2e-03` has a different target than the other two projects. The target is `or8n`
+This target project executes `pwc-p` command. When using it in multiple machines it will execute in parallel the tests of this project.
+
+```sh
+CURRENTS_RECORD_KEY=recordkey \
+CURRENTS_PROJECT_ID=projectid \
+CURRENTS_CI_BUILD_ID=`date +%s` \
+nx run-many -t or8n
+
+# ...
+
+ NX   Running target or8n for 1 project
+
+   ⠙  nx run e2e-03:or8n
+```
+
+The `parallel` flag is no longer needed as it is running a single nx project.
+
+The `or8n.yml` file has an example for running it in Github actions.

--- a/apps/e2e-03/eslint.config.js
+++ b/apps/e2e-03/eslint.config.js
@@ -1,0 +1,13 @@
+const playwright = require('eslint-plugin-playwright');
+const baseConfig = require('../../eslint.config.js');
+
+module.exports = [
+  playwright.configs['flat/recommended'],
+
+  ...baseConfig,
+  {
+    files: ['**/*.ts', '**/*.js'],
+    // Override or add rules here
+    rules: {},
+  },
+];

--- a/apps/e2e-03/playwright.config.ts
+++ b/apps/e2e-03/playwright.config.ts
@@ -1,0 +1,20 @@
+import { nxE2EPreset } from '@nx/playwright/preset';
+import { defineConfig, devices } from '@playwright/test';
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { reporter } from '../../playwright.config';
+
+const nxConf = nxE2EPreset(__filename);
+export default defineConfig({
+  ...nxConf,
+  reporter,
+  testDir: './src',
+  use: {
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/apps/e2e-03/project.json
+++ b/apps/e2e-03/project.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "name": "e2e-03",
+  "projectType": "application",
+  "sourceRoot": "apps/e2e-03/src",
+  "targets": {
+    "or8n": {
+      "executor": "nx:run-commands",
+      "options": {
+        "config": "apps/e2e-03/playwright.config.ts",
+        "commands": [
+          {
+            "command": "npx pwc-p"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/apps/e2e-03/src/e2e-03-1.spec.ts
+++ b/apps/e2e-03/src/e2e-03-1.spec.ts
@@ -1,0 +1,5 @@
+import { expect, test } from '@playwright/test';
+
+test('e2e-03-1', async () => {
+  expect(1).toBe(1);
+});

--- a/apps/e2e-03/src/e2e-03-2.spec.ts
+++ b/apps/e2e-03/src/e2e-03-2.spec.ts
@@ -1,0 +1,5 @@
+import { expect, test } from '@playwright/test';
+
+test('e2e-03-2', async () => {
+  expect(1).toBe(1);
+});

--- a/apps/e2e-03/src/e2e-03.spec.ts
+++ b/apps/e2e-03/src/e2e-03.spec.ts
@@ -1,0 +1,5 @@
+import { expect, test } from '@playwright/test';
+
+test('e2e-03', async () => {
+  expect(1).toBe(1);
+});

--- a/apps/e2e-03/tsconfig.json
+++ b/apps/e2e-03/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "sourceMap": false
+  },
+  "include": [
+    "**/*.ts",
+    "**/*.js",
+    "playwright.config.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.spec.js",
+    "src/**/*.test.ts",
+    "src/**/*.test.js",
+    "src/**/*.d.ts"
+  ]
+}


### PR DESCRIPTION
This PR adds an example to use or8n in a single nx project.

The main idea is that all the tests in the nx project `e2e-03` are orchestrated by executing `pwc-p` as command.

The project target is `or8n` an can be executed by:
```
CURRENTS_RECORD_KEY=recordkey \
CURRENTS_PROJECT_ID=projectid \
CURRENTS_CI_BUILD_ID=unique-id \
nx run-many -t or8n
```

If executed locally in 2 machines it will create a single run (based on the ci build id) parallelizing the tests in the 2 machines.
In CI it will orchestrate the tests across the machines defined in the matrix strategy.